### PR TITLE
Added support for Laravel 6.x

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -5,9 +5,6 @@ use Illuminate\Routing\Controller as BaseController;
 use App\Forms\LaravelSettingsForm;
 use Illuminate\Support\Facades\Config;
 use Kris\LaravelFormBuilder\FormBuilder;
-use \Illuminate\Support\Facades\Input;
-use \Illuminate\Support\Facades\Redirect;
-use \Illuminate\Support\Facades\Validator;
 use \anlutro\LaravelSettings\Facade as Setting;
 
 class Controller extends BaseController
@@ -34,21 +31,18 @@ class Controller extends BaseController
         return view("laravel-settings-ui::settings", ['form' => $form]);
     }
 
-    public function post(FormBuilder $formBuilder)
+    public function post(FormBuilder $formBuilder, Request $request)
     {
         $form = $formBuilder->create($this->getForm(), [
             'method' => 'post'
         ]);
 
-        $rules = [];
-        $validator = Validator::make($form->getAllAttributes(), $rules);
-
-        if ($validator->fails()) {
-            return Redirect::to(route("laravel-settings-ui"))
-                ->withErrors($validator)
+        if (! $form->isValid()) {
+            return redirect()->back()
+                ->withErrors($form->getErrors())
                 ->withInput();
         } else {
-            $inputs = Input::only($form->getAllAttributes());
+            $inputs = $request->only($form->getAllAttributes());
 
             foreach ($inputs As $key => $value) {
                 if (empty($key)) continue;


### PR DESCRIPTION
Input Facade no longer exists in Laravel 6.x.
see https://laravel.com/docs/6.0/upgrade#the-input-facade

This commit include also the other fix here https://github.com/imTigger/laravel-settings-ui/pull/3

Since I forgot in first pull request to add this fix.